### PR TITLE
fixed hot code reloading

### DIFF
--- a/myapi/build.gradle
+++ b/myapi/build.gradle
@@ -54,10 +54,18 @@ dependencies {
     testCompile "org.grails:grails-datastore-rest-client"
     testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"
     testRuntime "net.sourceforge.htmlunit:htmlunit:2.18"
-    compile project(':myplugin')
+    //compile project(':myplugin')
+    // doesn't do hot code reloading
 }
 
 bootRun {
     jvmArgs('-Dspring.output.ansi.enabled=always')
     addResources = true
+}
+
+// does do hot code reloading, but only with grails run-app
+grails {
+    plugins {
+        compile project(':myplugin')
+    }
 }


### PR DESCRIPTION
Hi Sergio,

Started the application from the root with `gradlew bootRun`, but hot code reloading didn't work yet -- a bit as expected, but one would maybe hope that with Gradle 3.4.1 and Grails 3.2.8 this somehow would have worked out of the box. But no. 

So, we still need the "plugins" block.

Regards, Ted